### PR TITLE
feat: add statement_type function for SPARQL statement classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,31 @@ formatted = sparqlkit.format_string(query)
 print(formatted)
 ```
 
+### Statement type detection
+
+Determine the type and sub-type of a SPARQL statement:
+
+```python
+import sparqlkit
+
+# From a statement string
+result = sparqlkit.statement_type_from_string("SELECT * WHERE { ?s ?p ?o }")
+print(result.type)     # SparqlType.QUERY
+print(result.subtype)  # QuerySubType.SELECT
+
+# From a parsed tree
+tree = sparqlkit.parse("INSERT DATA { <s> <p> <o> }")
+result = sparqlkit.statement_type(tree)
+print(result.type)     # SparqlType.UPDATE
+print(result.subtype)  # UpdateSubType.INSERT_DATA
+```
+
+Supported query sub-types: `SELECT`, `CONSTRUCT`, `DESCRIBE`, `ASK`
+
+Supported update sub-types: `INSERT_WHERE`, `INSERT_DATA`, `DELETE_WHERE`, `DELETE_DATA`, `MODIFY`, `DROP`, `CLEAR`, `LOAD`, `CREATE`, `ADD`, `MOVE`, `COPY`
+
+Note: `MODIFY` includes both `INSERT` and `DELETE` operations. E.g., `DELETE {…} INSERT {…} WHERE {…}`
+
 ### Preserving comments
 
 Comments are preserved end-to-end through `format_string` and `parse`/`serialize` by default.

--- a/sparqlkit/__init__.py
+++ b/sparqlkit/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Literal
 
 from lark import Token, Tree
@@ -28,9 +30,57 @@ __all__ = [
     "validate",
     "validate_query",
     "validate_update",
+    "statement_type",
+    "statement_type_from_string",
     "SparqlSyntaxError",
+    "SparqlTypeError",
+    "SparqlType",
+    "QuerySubType",
+    "UpdateSubType",
+    "SparqlStatementType",
     "ParserType",
 ]
+
+
+class SparqlType(Enum):
+    """The top-level type of a SPARQL statement."""
+
+    QUERY = "query"
+    UPDATE = "update"
+
+
+class QuerySubType(Enum):
+    """Sub-types for SPARQL queries."""
+
+    SELECT = "select"
+    CONSTRUCT = "construct"
+    DESCRIBE = "describe"
+    ASK = "ask"
+
+
+class UpdateSubType(Enum):
+    """Sub-types for SPARQL updates."""
+
+    INSERT_WHERE = "insert_where"
+    INSERT_DATA = "insert_data"
+    MODIFY = "modify"
+    DELETE_WHERE = "delete_where"
+    DELETE_DATA = "delete_data"
+    DROP = "drop"
+    CLEAR = "clear"
+    LOAD = "load"
+    CREATE = "create"
+    ADD = "add"
+    MOVE = "move"
+    COPY = "copy"
+
+
+@dataclass
+class SparqlStatementType:
+    """The type and sub-type of a SPARQL statement."""
+
+    type: SparqlType
+    subtype: QuerySubType | UpdateSubType
 
 
 class SparqlSyntaxError(Exception):
@@ -63,6 +113,10 @@ class SparqlSyntaxError(Exception):
         if self.line is not None and self.column is not None:
             return f"{self.message} (line {self.line}, column {self.column})"
         return self.message
+
+
+class SparqlTypeError(Exception):
+    """Raised when unable to determine the SPARQL statement type."""
 
 
 def _wrap_lark_error(error: Exception, parser_type: str) -> SparqlSyntaxError:
@@ -412,3 +466,141 @@ def serialize(
     # Normalize leading/trailing whitespace/newlines so callers get stable output
     # regardless of input surrounding whitespace.
     return serializer.result.strip()
+
+
+def _find_child(tree: Tree[Any], *names: str) -> Tree[Any] | None:
+    """Find the first child tree with one of the given names."""
+    for child in tree.children:
+        if isinstance(child, Tree) and child.data in names:
+            return child
+    return None
+
+
+def _has_child(tree: Tree[Any], name: str) -> bool:
+    """Check if a tree has a child with the given name."""
+    return any(
+        isinstance(child, Tree) and child.data == name for child in tree.children
+    )
+
+
+_QUERY_SUBTYPE_MAP: dict[str, QuerySubType] = {
+    "select_query": QuerySubType.SELECT,
+    "construct_query": QuerySubType.CONSTRUCT,
+    "describe_query": QuerySubType.DESCRIBE,
+    "ask_query": QuerySubType.ASK,
+}
+
+_UPDATE_SUBTYPE_MAP: dict[str, UpdateSubType] = {
+    "load": UpdateSubType.LOAD,
+    "clear": UpdateSubType.CLEAR,
+    "drop": UpdateSubType.DROP,
+    "add": UpdateSubType.ADD,
+    "move": UpdateSubType.MOVE,
+    "copy": UpdateSubType.COPY,
+    "create": UpdateSubType.CREATE,
+    "insert_data": UpdateSubType.INSERT_DATA,
+    "delete_data": UpdateSubType.DELETE_DATA,
+}
+
+
+def _get_modify_subtype(modify_tree: Tree[Any]) -> UpdateSubType:
+    """Determine the subtype of a modify operation."""
+    has_delete = _has_child(modify_tree, "delete_clause")
+    has_insert = _has_child(modify_tree, "insert_clause")
+
+    if has_delete and has_insert:
+        return UpdateSubType.MODIFY
+    elif has_insert:
+        return UpdateSubType.INSERT_WHERE
+    else:
+        return UpdateSubType.DELETE_WHERE
+
+
+def _get_update_subtype(update1_tree: Tree[Any]) -> UpdateSubType:
+    """Determine the subtype of an update1 node."""
+    for child in update1_tree.children:
+        if isinstance(child, Tree):
+            if child.data in _UPDATE_SUBTYPE_MAP:
+                return _UPDATE_SUBTYPE_MAP[child.data]
+            elif child.data == "delete_where":
+                return UpdateSubType.DELETE_WHERE
+            elif child.data == "modify":
+                return _get_modify_subtype(child)
+
+    raise SparqlTypeError(f"Unknown update subtype in tree: {update1_tree}")
+
+
+def statement_type(tree: Tree[Any]) -> SparqlStatementType:
+    """Determine the type and sub-type of a SPARQL statement from its AST.
+
+    :param tree: A lark.Tree representing a parsed SPARQL query or update.
+    :return: A SparqlStatementType with the type and subtype.
+    :raises SparqlTypeError: If the statement type cannot be determined.
+    """
+    if not isinstance(tree, Tree):
+        raise SparqlTypeError(f"Expected a Tree, got {type(tree).__name__}")
+
+    root = tree
+    if root.data == "unit":
+        child = _find_child(root, "query_unit", "update_unit")
+        if child is None:
+            raise SparqlTypeError("No query_unit or update_unit found in tree")
+        root = child
+
+    if root.data == "query_unit":
+        query_tree = _find_child(root, "query")
+        if query_tree is None:
+            raise SparqlTypeError("No query found in query_unit")
+
+        for name, subtype in _QUERY_SUBTYPE_MAP.items():
+            if _find_child(query_tree, name) is not None:
+                return SparqlStatementType(SparqlType.QUERY, subtype)
+
+        raise SparqlTypeError("Unknown query subtype")
+
+    elif root.data == "update_unit":
+        update_tree = _find_child(root, "update")
+        if update_tree is None:
+            raise SparqlTypeError("No update found in update_unit")
+
+        update1_tree = _find_child(update_tree, "update1")
+        if update1_tree is None:
+            raise SparqlTypeError("No update1 found in update")
+
+        update_subtype = _get_update_subtype(update1_tree)
+        return SparqlStatementType(SparqlType.UPDATE, update_subtype)
+
+    elif root.data == "query":
+        for name, query_subtype in _QUERY_SUBTYPE_MAP.items():
+            if _find_child(root, name) is not None:
+                return SparqlStatementType(SparqlType.QUERY, query_subtype)
+        raise SparqlTypeError("Unknown query subtype")
+
+    elif root.data == "update":
+        update1_tree = _find_child(root, "update1")
+        if update1_tree is None:
+            raise SparqlTypeError("No update1 found in update")
+
+        update_subtype = _get_update_subtype(update1_tree)
+        return SparqlStatementType(SparqlType.UPDATE, update_subtype)
+
+    else:
+        raise SparqlTypeError(f"Unexpected root node: {root.data}")
+
+
+def statement_type_from_string(
+    query: str,
+    parser_type: ParserType | None = None,
+) -> SparqlStatementType:
+    """Parse a SPARQL string and determine its statement type and sub-type.
+
+    This is a convenience function that combines parse() and statement_type().
+
+    :param query: Input SPARQL query or update string.
+    :param parser_type: Optional parser type. If None, uses unified grammar.
+    :return: A SparqlStatementType with the type and subtype.
+    :raises SparqlSyntaxError: If the query has a syntax error.
+    :raises SparqlTypeError: If the statement type cannot be determined.
+    """
+    tree = parse(query, parser_type=parser_type, preserve_comments=False)
+    return statement_type(tree)

--- a/tests/test_statement_type.py
+++ b/tests/test_statement_type.py
@@ -1,0 +1,197 @@
+import pytest
+from lark import Tree
+
+from sparqlkit import (
+    QuerySubType,
+    SparqlStatementType,
+    SparqlType,
+    SparqlTypeError,
+    UpdateSubType,
+    parse,
+    statement_type,
+    statement_type_from_string,
+)
+
+# Query type tests
+
+
+def test_select():
+    query = "SELECT * WHERE { ?s ?p ?o }"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.QUERY, QuerySubType.SELECT)
+
+
+def test_construct():
+    query = "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.QUERY, QuerySubType.CONSTRUCT)
+
+
+def test_describe():
+    query = "DESCRIBE <http://example.org>"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.QUERY, QuerySubType.DESCRIBE)
+
+
+def test_ask():
+    query = "ASK { ?s ?p ?o }"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.QUERY, QuerySubType.ASK)
+
+
+# Update type tests
+
+
+def test_insert_data():
+    query = "INSERT DATA { <s> <p> <o> }"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.INSERT_DATA)
+
+
+def test_delete_data():
+    query = "DELETE DATA { <s> <p> <o> }"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.DELETE_DATA)
+
+
+def test_delete_where():
+    query = "DELETE WHERE { ?s ?p ?o }"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.DELETE_WHERE)
+
+
+def test_insert_where():
+    query = "INSERT { ?s ?p ?o } WHERE { ?s ?p ?o }"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.INSERT_WHERE)
+
+
+def test_delete_where_modify():
+    query = "DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.DELETE_WHERE)
+
+
+def test_modify():
+    query = "DELETE { ?s ?p ?o } INSERT { ?s ?p ?o } WHERE { ?s ?p ?o }"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.MODIFY)
+
+
+def test_drop():
+    query = "DROP ALL"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.DROP)
+
+
+def test_clear():
+    query = "CLEAR DEFAULT"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.CLEAR)
+
+
+def test_load():
+    query = "LOAD <http://example.org>"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.LOAD)
+
+
+def test_create():
+    query = "CREATE GRAPH <http://example.org>"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.CREATE)
+
+
+def test_add():
+    query = "ADD DEFAULT TO <http://example.org>"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.ADD)
+
+
+def test_move():
+    query = "MOVE DEFAULT TO <http://example.org>"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.MOVE)
+
+
+def test_copy():
+    query = "COPY DEFAULT TO <http://example.org>"
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.COPY)
+
+
+# Tests with pre-parsed trees
+
+
+def test_statement_type_from_parsed_tree():
+    query = "SELECT * WHERE { ?s ?p ?o }"
+    tree = parse(query)
+    result = statement_type(tree)
+    assert result == SparqlStatementType(SparqlType.QUERY, QuerySubType.SELECT)
+
+
+def test_statement_type_from_update_tree():
+    query = "INSERT DATA { <s> <p> <o> }"
+    tree = parse(query)
+    result = statement_type(tree)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.INSERT_DATA)
+
+
+# Error handling tests
+
+
+def test_invalid_tree_type():
+    with pytest.raises(SparqlTypeError, match="Expected a Tree"):
+        statement_type("not a tree")
+
+
+def test_unexpected_root_node():
+    invalid_tree = Tree("unknown_node", [])
+    with pytest.raises(SparqlTypeError, match="Unexpected root node"):
+        statement_type(invalid_tree)
+
+
+def test_empty_unit_tree():
+    invalid_tree = Tree("unit", [])
+    with pytest.raises(SparqlTypeError, match="No query_unit or update_unit"):
+        statement_type(invalid_tree)
+
+
+# Tests with explicit parser_type
+
+
+def test_query_with_sparql_parser():
+    query = "SELECT * WHERE { ?s ?p ?o }"
+    result = statement_type_from_string(query, parser_type="sparql")
+    assert result == SparqlStatementType(SparqlType.QUERY, QuerySubType.SELECT)
+
+
+def test_update_with_update_parser():
+    query = "INSERT DATA { <s> <p> <o> }"
+    result = statement_type_from_string(query, parser_type="sparql_update")
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.INSERT_DATA)
+
+
+# Tests with prefixes
+
+
+def test_select_with_prefix():
+    query = """
+    PREFIX ex: <http://example.org/>
+    SELECT * WHERE { ?s ex:predicate ?o }
+    """
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.QUERY, QuerySubType.SELECT)
+
+
+def test_insert_data_with_prefix():
+    query = """
+    PREFIX ex: <http://example.org/>
+    INSERT DATA { ex:s ex:p ex:o }
+    """
+    result = statement_type_from_string(query)
+    assert result == SparqlStatementType(SparqlType.UPDATE, UpdateSubType.INSERT_DATA)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
- Add SparqlType enum (QUERY, UPDATE)

- Add QuerySubType enum (SELECT, CONSTRUCT, DESCRIBE, ASK)

- Add UpdateSubType enum (INSERT_WHERE, INSERT_DATA, MODIFY, DELETE_WHERE, DELETE_DATA, DROP, CLEAR, LOAD, CREATE, ADD, MOVE, COPY)

- Add SparqlStatementType dataclass to represent type and subtype

- Add SparqlTypeError exception for classification errors

- Add statement_type() to classify parsed AST

- Add statement_type_from_string() convenience function

- Add comprehensive test suite in test_statement_type.py

- Update README with usage documentation